### PR TITLE
Add the pilz/LINI trajectory generator

### DIFF
--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -77,8 +77,11 @@ moveit_msgs::msg::Constraints mergeConstraints(const moveit_msgs::msg::Constrain
         double high = std::min(a.position + a.tolerance_above, b.position + b.tolerance_above);
         if (low > high)
         {
-          RCLCPP_ERROR(LOGGER, "Attempted to merge incompatible constraints for joint '%s'. Discarding constraint.",
-                       a.joint_name.c_str());
+          RCLCPP_ERROR_STREAM(LOGGER, "Attempted to merge incompatible constraints for joint '"
+                                          << a.joint_name << "' (" << (a.position - a.tolerance_below) << " < j < "
+                                          << (a.position + a.tolerance_above) << ") incompatible with ("
+                                          << (b.position - b.tolerance_below) << " < j < "
+                                          << (b.position + b.tolerance_above) << "). Discarding constraint.");
         }
         else
         {

--- a/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
@@ -141,6 +141,14 @@ add_library(planning_context_loader_lin SHARED
 ament_target_dependencies(planning_context_loader_lin ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(planning_context_loader_lin planning_context_loader_base joint_limits_common trajectory_generation_common)
 
+add_library(planning_context_loader_lini SHARED
+  src/planning_context_loader_lini.cpp
+  src/trajectory_generator_lini.cpp
+  src/velocity_profile_atrap.cpp
+)
+ament_target_dependencies(planning_context_loader_lini ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(planning_context_loader_lini planning_context_loader_base joint_limits_common trajectory_generation_common)
+
 add_library(planning_context_loader_circ SHARED
   src/planning_context_loader_circ.cpp
   src/trajectory_generator_circ.cpp

--- a/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
@@ -180,6 +180,7 @@ install(
     planning_context_loader_base
     planning_context_loader_ptp
     planning_context_loader_lin
+    planning_context_loader_lini
     planning_context_loader_circ
     command_list_manager
     sequence_capability

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/command_list_manager.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/command_list_manager.h
@@ -85,7 +85,7 @@ public:
    *
    * @param planning_scene The planning scene to be used for trajectory
    * generation.
-   * @param req_list List of motion requests containing: PTP, LIN, CIRC
+   * @param req_list List of motion requests containing: PTP, LIN, LINI, CIRC
    * and/or gripper commands.
    * Please note: A request is only valid if:
    *    - All blending radii are non negative.

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_lini.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_lini.h
@@ -45,21 +45,21 @@
 #include <thread>
 
 #include "pilz_industrial_motion_planner/planning_context_base.h"
-#include "pilz_industrial_motion_planner/trajectory_generator_lin.h"
+#include "pilz_industrial_motion_planner/trajectory_generator_lini.h"
 
 namespace pilz_industrial_motion_planner
 {
 MOVEIT_CLASS_FORWARD(PlanningContext);
 
 /**
- * @brief PlanningContext for obtaining LIN trajectories
+ * @brief PlanningContext for obtaining LINI trajectories
  */
-class PlanningContextLIN : public pilz_industrial_motion_planner::PlanningContextBase<TrajectoryGeneratorLIN>
+class PlanningContextLINI : public pilz_industrial_motion_planner::PlanningContextBase<TrajectoryGeneratorLINI>
 {
 public:
-  PlanningContextLIN(const std::string& name, const std::string& group, const moveit::core::RobotModelConstPtr& model,
-                     const pilz_industrial_motion_planner::LimitsContainer& limits)
-    : pilz_industrial_motion_planner::PlanningContextBase<TrajectoryGeneratorLIN>(name, group, model, limits)
+  PlanningContextLINI(const std::string& name, const std::string& group, const moveit::core::RobotModelConstPtr& model,
+                      const pilz_industrial_motion_planner::LimitsContainer& limits)
+    : pilz_industrial_motion_planner::PlanningContextBase<TrajectoryGeneratorLINI>(name, group, model, limits)
   {
   }
 };

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_loader_lini.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_loader_lini.h
@@ -34,34 +34,35 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/limits_container.h"
-
-#include <rclcpp/rclcpp.hpp>
+#include "pilz_industrial_motion_planner/planning_context_loader.h"
 
 #include <moveit/planning_interface/planning_interface.h>
-#include <moveit/planning_interface/planning_response.h>
-
-#include <atomic>
-#include <thread>
-
-#include "pilz_industrial_motion_planner/planning_context_base.h"
-#include "pilz_industrial_motion_planner/trajectory_generator_lin.h"
 
 namespace pilz_industrial_motion_planner
 {
-MOVEIT_CLASS_FORWARD(PlanningContext);
-
 /**
- * @brief PlanningContext for obtaining LIN trajectories
+ * @brief Plugin that can generate instances of PlanningContextLINI.
+ * Generates instances of PlanningContextLINI.
  */
-class PlanningContextLIN : public pilz_industrial_motion_planner::PlanningContextBase<TrajectoryGeneratorLIN>
+class PlanningContextLoaderLINI : public PlanningContextLoader
 {
 public:
-  PlanningContextLIN(const std::string& name, const std::string& group, const moveit::core::RobotModelConstPtr& model,
-                     const pilz_industrial_motion_planner::LimitsContainer& limits)
-    : pilz_industrial_motion_planner::PlanningContextBase<TrajectoryGeneratorLIN>(name, group, model, limits)
-  {
-  }
+  PlanningContextLoaderLINI();
+  ~PlanningContextLoaderLINI() override;
+
+  /**
+   * @brief return a instance of
+   * pilz_industrial_motion_planner::PlanningContextLINI
+   * @param planning_context returned context
+   * @param name
+   * @param group
+   * @return true on success, false otherwise
+   */
+  bool loadContext(planning_interface::PlanningContextPtr& planning_context, const std::string& name,
+                   const std::string& group) const override;
 };
+
+typedef boost::shared_ptr<PlanningContextLoaderLINI> PlanningContextLoaderLINIPtr;
+typedef boost::shared_ptr<const PlanningContextLoaderLINI> PlanningContextLoaderLINIConstPtr;
 
 }  // namespace pilz_industrial_motion_planner

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_lini.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_lini.h
@@ -1,0 +1,88 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018 Pilz GmbH & Co. KG
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Pilz GmbH & Co. KG nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#pragma once
+
+#include <eigen3/Eigen/Eigen>
+#include <kdl/rotational_interpolation_sa.hpp>
+#include <moveit/planning_scene/planning_scene.h>
+
+#include "pilz_industrial_motion_planner/trajectory_generator.h"
+#include "pilz_industrial_motion_planner/velocity_profile_atrap.h"
+
+namespace pilz_industrial_motion_planner
+{
+// TODO date type of units
+
+CREATE_MOVEIT_ERROR_CODE_EXCEPTION(LiniTrajectoryConversionFailure, moveit_msgs::msg::MoveItErrorCodes::FAILURE);
+
+CREATE_MOVEIT_ERROR_CODE_EXCEPTION(JointNumberMismatch, moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
+CREATE_MOVEIT_ERROR_CODE_EXCEPTION(LiniJointMissingInStartState,
+                                   moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE);
+CREATE_MOVEIT_ERROR_CODE_EXCEPTION(LiniInverseForGoalIncalculable, moveit_msgs::msg::MoveItErrorCodes::NO_IK_SOLUTION);
+
+/**
+ * @brief This class implements a linear trajectory generator in Cartesian
+ * space.
+ * The Cartesian trajetory are based on trapezoid velocity profile.
+ */
+class TrajectoryGeneratorLINI : public TrajectoryGenerator
+{
+public:
+  /**
+   * @brief Constructor of LINI Trajectory Generator
+   * @throw TrajectoryGeneratorInvalidLimitsException
+   * @param model: robot model
+   * @param planner_limits: limits in joint and Cartesian spaces
+   */
+  TrajectoryGeneratorLINI(const moveit::core::RobotModelConstPtr& robot_model,
+                          const pilz_industrial_motion_planner::LimitsContainer& planner_limits,
+                          const std::string& group_name);
+
+private:
+  void extractMotionPlanInfo(const planning_scene::PlanningSceneConstPtr& scene,
+                             const planning_interface::MotionPlanRequest& req, MotionPlanInfo& info) const final;
+
+  void plan(const planning_scene::PlanningSceneConstPtr& scene, const planning_interface::MotionPlanRequest& req,
+            const MotionPlanInfo& plan_info, const double& sampling_time,
+            trajectory_msgs::msg::JointTrajectory& joint_trajectory) override;
+
+  /**
+   * @brief construct a KDL::Path object for a Cartesian straight line
+   * @return a unique pointer of the path object. null_ptr in case of an error.
+   */
+  std::unique_ptr<KDL::Path> setPathLIN(const Eigen::Affine3d& start_pose, const Eigen::Affine3d& goal_pose) const;
+};
+
+}  // namespace pilz_industrial_motion_planner

--- a/moveit_planners/pilz_industrial_motion_planner/plugins/planning_context_plugin_description.xml
+++ b/moveit_planners/pilz_industrial_motion_planner/plugins/planning_context_plugin_description.xml
@@ -13,6 +13,13 @@
       <description>Loader for LIN Context</description>
     </class>
   </library>
+  <library path="planning_context_loader_lini">
+    <class name="pilz_industrial_motion_planner/PlanningContextLoaderLINI"
+           type="pilz_industrial_motion_planner::PlanningContextLoaderLINI"
+           base_class_type="pilz_industrial_motion_planner::PlanningContextLoader">
+    <description>Loader for LINI Context</description>
+    </class>
+  </library>
   <library path="planning_context_loader_circ">
     <class name="pilz_industrial_motion_planner/PlanningContextLoaderCIRC"
            type="pilz_industrial_motion_planner::PlanningContextLoaderCIRC"

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lini.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lini.cpp
@@ -180,8 +180,8 @@ void TrajectoryGeneratorLINI::plan(const planning_scene::PlanningSceneConstPtr& 
   // sample the Cartesian trajectory and compute joint trajectory using inverse
   // kinematics
   if (!generateJointTrajectory(scene, planner_limits_.getJointLimitContainer(), cart_trajectory, plan_info.group_name,
-                               plan_info.link_name, plan_info.start_joint_position, sampling_time, joint_trajectory,
-                               error_code))
+                               plan_info.link_name, plan_info.start_joint_position, plan_info.goal_joint_position,
+                               sampling_time, joint_trajectory, error_code))
   {
     std::ostringstream os;
     os << "Failed to generate valid joint trajectory from the Cartesian path";

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lini.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lini.cpp
@@ -1,0 +1,208 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018 Pilz GmbH & Co. KG
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Pilz GmbH & Co. KG nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "pilz_industrial_motion_planner/trajectory_generator_lini.h"
+
+#include <cassert>
+#include <rclcpp/rclcpp.hpp>
+#include <sstream>
+#include <time.h>
+
+#include <moveit/robot_state/conversions.h>
+
+#include <kdl/path_line.hpp>
+#include <kdl/trajectory_segment.hpp>
+#include <kdl/utilities/error.h>
+
+#include <tf2/convert.h>
+#include <tf2_eigen_kdl/tf2_eigen_kdl.hpp>
+#if __has_include(<tf2_eigen/tf2_eigen.hpp>)
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#else
+#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#endif
+
+namespace pilz_industrial_motion_planner
+{
+static const rclcpp::Logger LOGGER =
+    rclcpp::get_logger("moveit.pilz_industrial_motion_planner.trajectory_generator_lini");
+TrajectoryGeneratorLINI::TrajectoryGeneratorLINI(const moveit::core::RobotModelConstPtr& robot_model,
+                                                 const LimitsContainer& planner_limits,
+                                                 const std::string& /*group_name*/)
+  : TrajectoryGenerator::TrajectoryGenerator(robot_model, planner_limits)
+{
+  if (!planner_limits_.hasFullCartesianLimits())
+  {
+    RCLCPP_ERROR(LOGGER, "Cartesian limits not set for LINI trajectory generator.");
+    throw TrajectoryGeneratorInvalidLimitsException(
+        "Cartesian limits are not fully set for LINI trajectory generator.");
+  }
+}
+
+void TrajectoryGeneratorLINI::extractMotionPlanInfo(const planning_scene::PlanningSceneConstPtr& scene,
+                                                    const planning_interface::MotionPlanRequest& req,
+                                                    TrajectoryGenerator::MotionPlanInfo& info) const
+{
+  RCLCPP_DEBUG(LOGGER, "Extract necessary information from motion plan request.");
+
+  info.group_name = req.group_name;
+  std::string frame_id{ robot_model_->getModelFrame() };
+
+  // goal given in joint space
+  if (!req.goal_constraints.front().joint_constraints.empty())
+  {
+    info.link_name = robot_model_->getJointModelGroup(req.group_name)->getSolverInstance()->getTipFrame();
+
+    if (req.goal_constraints.front().joint_constraints.size() !=
+        robot_model_->getJointModelGroup(req.group_name)->getActiveJointModelNames().size())
+    {
+      std::ostringstream os;
+      os << "Number of joints in goal does not match number of joints of group "
+            "(Number joints goal: "
+         << req.goal_constraints.front().joint_constraints.size() << " | Number of joints of group: "
+         << robot_model_->getJointModelGroup(req.group_name)->getActiveJointModelNames().size() << ")";
+      throw JointNumberMismatch(os.str());
+    }
+    // initializing all joints of the model
+    for (const auto& joint_name : robot_model_->getVariableNames())
+    {
+      info.goal_joint_position[joint_name] = 0;
+    }
+
+    for (const auto& joint_item : req.goal_constraints.front().joint_constraints)
+    {
+      info.goal_joint_position[joint_item.joint_name] = joint_item.position;
+    }
+
+    // Ignored return value because at this point the function should always
+    // return 'true'.
+    computeLinkFK(robot_model_, info.link_name, info.goal_joint_position, info.goal_pose);
+  }
+  // goal given in Cartesian space
+  else
+  {
+    info.link_name = req.goal_constraints.front().position_constraints.front().link_name;
+    if (req.goal_constraints.front().position_constraints.front().header.frame_id.empty() ||
+        req.goal_constraints.front().orientation_constraints.front().header.frame_id.empty())
+    {
+      RCLCPP_WARN(LOGGER, "Frame id is not set in position/orientation constraints of "
+                          "goal. Use model frame as default");
+      frame_id = robot_model_->getModelFrame();
+    }
+    else
+    {
+      frame_id = req.goal_constraints.front().position_constraints.front().header.frame_id;
+    }
+    info.goal_pose = getConstraintPose(req.goal_constraints.front());
+  }
+
+  assert(req.start_state.joint_state.name.size() == req.start_state.joint_state.position.size());
+  for (const auto& joint_name : robot_model_->getJointModelGroup(req.group_name)->getActiveJointModelNames())
+  {
+    auto it{ std::find(req.start_state.joint_state.name.cbegin(), req.start_state.joint_state.name.cend(), joint_name) };
+    if (it == req.start_state.joint_state.name.cend())
+    {
+      std::ostringstream os;
+      os << "Could not find joint \"" << joint_name << "\" of group \"" << req.group_name
+         << "\" in start state of request";
+      throw LiniJointMissingInStartState(os.str());
+    }
+    size_t index = it - req.start_state.joint_state.name.cbegin();
+    info.start_joint_position[joint_name] = req.start_state.joint_state.position[index];
+  }
+
+  // Ignored return value because at this point the function should always
+  // return 'true'.
+  computeLinkFK(robot_model_, info.link_name, info.start_joint_position, info.start_pose);
+
+  // check goal pose ik before Cartesian motion plan starts
+  std::map<std::string, double> ik_solution;
+  if (!computePoseIK(scene, info.group_name, info.link_name, info.goal_pose, frame_id, info.start_joint_position,
+                     ik_solution))
+  {
+    std::ostringstream os;
+    os << "Failed to compute inverse kinematics for link: " << info.link_name << " of goal pose";
+    throw LiniInverseForGoalIncalculable(os.str());
+  }
+}
+
+void TrajectoryGeneratorLINI::plan(const planning_scene::PlanningSceneConstPtr& scene,
+                                   const planning_interface::MotionPlanRequest& req, const MotionPlanInfo& plan_info,
+                                   const double& sampling_time, trajectory_msgs::msg::JointTrajectory& joint_trajectory)
+{
+  // create Cartesian path for lini
+  std::unique_ptr<KDL::Path> path(setPathLIN(plan_info.start_pose, plan_info.goal_pose));
+
+  // create velocity profile
+  std::unique_ptr<KDL::VelocityProfile> vp(
+      cartesianTrapVelocityProfile(req.max_velocity_scaling_factor, req.max_acceleration_scaling_factor, path));
+
+  // combine path and velocity profile into Cartesian trajectory
+  // with the third parameter set to false, KDL::Trajectory_Segment does not
+  // take
+  // the ownship of Path and Velocity Profile
+  KDL::Trajectory_Segment cart_trajectory(path.get(), vp.get(), false);
+
+  moveit_msgs::msg::MoveItErrorCodes error_code;
+  // sample the Cartesian trajectory and compute joint trajectory using inverse
+  // kinematics
+  if (!generateJointTrajectory(scene, planner_limits_.getJointLimitContainer(), cart_trajectory, plan_info.group_name,
+                               plan_info.link_name, plan_info.start_joint_position, sampling_time, joint_trajectory,
+                               error_code))
+  {
+    std::ostringstream os;
+    os << "Failed to generate valid joint trajectory from the Cartesian path";
+    throw LiniTrajectoryConversionFailure(os.str(), error_code.val);
+  }
+}
+
+std::unique_ptr<KDL::Path> TrajectoryGeneratorLINI::setPathLIN(const Eigen::Affine3d& start_pose,
+                                                               const Eigen::Affine3d& goal_pose) const
+{
+  RCLCPP_DEBUG(LOGGER, "Set Cartesian path for LINI command.");
+
+  KDL::Frame kdl_start_pose, kdl_goal_pose;
+  tf2::transformEigenToKDL(start_pose, kdl_start_pose);
+  tf2::transformEigenToKDL(goal_pose, kdl_goal_pose);
+  double eqradius = planner_limits_.getCartesianLimits().getMaxTranslationalVelocity() /
+                    planner_limits_.getCartesianLimits().getMaxRotationalVelocity();
+  KDL::RotationalInterpolation* rot_interpo = new KDL::RotationalInterpolation_SingleAxis();
+
+  return std::unique_ptr<KDL::Path>(
+      std::make_unique<KDL::Path_Line>(kdl_start_pose, kdl_goal_pose, rot_interpo, eqradius, true));
+}
+
+}  // namespace pilz_industrial_motion_planner

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -145,7 +145,6 @@ public:
         const auto start = node_->now();
         do
         {
-          RCLCPP_DEBUG(LOGGER, "waitForExecution, wait_for");
           status = result_future.wait_for(50ms);
           if ((status == std::future_status::timeout) and ((node_->now() - start) > timeout))
           {


### PR DESCRIPTION
### Description

Add the LINI trajectory generator that interpolates the seed between the initial and final pose rather than taking the solution of the IK of the previous point as seed.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
